### PR TITLE
zm - change delete course to remove ALL course related links/todos/notes

### DIFF
--- a/api2.py
+++ b/api2.py
@@ -103,6 +103,12 @@ class CourseAPI(Resource):
         if not course:
             abort(404)
         try:
+            for link in course.links:
+	            db.session.delete(link)
+            for todo in course.toDoObjects:
+	            db.session.delete(todo)
+            for note in course.notes:
+	            db.session.delete(note)
             db.session.delete(course)
             db.session.commit()
         except SQLAlchemyError as e:


### PR DESCRIPTION
When we delete a class now all the related links/todos/notes for that class will also be removed from the backend.